### PR TITLE
Add support for Client Certificate Verification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Protect any HTTP service with HTTPS!
 1. [Features](#features)
 1. [Example](#example)
 1. [Getting Started](#getting-started)
-    1. [Secure Docker Registry Example](#secure-docker-registry-example)
-    1. [Secure Rancher Server Example](#secure-rancher-server-example)
-    1. [Docker Compose Example](#docker-compose-example)
+  1. [Secure Docker Registry Example](#secure-docker-registry-example)
+  1. [Secure Rancher Server Example](#secure-rancher-server-example)
+  1. [Secure Rancher Server Example using Docker Compose](#secure-rancher-server-example-using-docker-compose)
+  1. [Client Verification Example](#client-verification-example)
 1. [Arguments / Configuration](#arguments)
   
 ## Features
@@ -148,11 +149,10 @@ services:
 ### Client Verification Example
 
 ```sh
-# Start Rancher w/ default local port 8080
+# Start an nginx server that responds with the incoming request's headers on port 8080
 docker run -d --restart=always \
   --name http-server \
-  -v /data/rancher/mysql:/var/lib/mysql \
-  rancher/server:latest
+  brndnmtthws/nginx-echo-headers
 
 # Create an ssl-proxy with certs in /certs, requiring a client certificate auth, to point at the local http-server's port 8080 and include the client certificate's subject as an http header
 docker run -d --restart=always \
@@ -164,7 +164,7 @@ docker run -d --restart=always \
   -e 'CERT_PRIVATE_PATH=/certs/privkey.pem' \
   -e 'SSL_VERIFY_CLIENT=on' \
   -e 'CERT_CLIENT_PATH=/certs/clientchain.pem' \
-  -e 'ADD_PROXY_HEADER=SSL_CLIENT_SUBJECT $ssl_client_s_dn' \
+  -e 'ADD_PROXY_HEADER=X-Ssl-Client-Subject $ssl_client_s_dn' \
   -v '/certs:/certs:ro' \
   --link 'http-server:http-server' \
   justsml/ssl-proxy:latest

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ services:
 |PASSWORD           |               | Both PASSWORD and USERNAME must be set in order to use Basic authorization
 |PASSWD_PATH        | /etc/nginx/.htpasswd | Alternate auth support (don't combine with USERNAME/PASSWORD) Bind-mount a custom path to `/etc/nginx/.htpasswd`
 |ADD_HEADER         | Not set       | Useful for tagging routes in your infrastructure.
+|ADD_PROXY_HEADER   | Not set       | Useful for providing metadata to the upstream server.
 
 
 ===================

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -62,6 +62,14 @@ if [ "$ALLOW_RC4" != "" ]; then
 else
   HTTPS_RC4=" !RC4 "
 fi
+if [ "$SSL_VERIFY_CLIENT" != "" ]; then
+  if [ "$SSL_VERIFY_CLIENT" != "optional_no_ca" ]; then
+    if [ ! -f "$CERT_CLIENT_PATH" ]; then
+      printf >&2 "Sh*t, '\$CERT_CLIENT_PATH' not found!\nNOT_FOUND: $CERT_CLIENT_PATH"
+      exit -65
+    fi
+  fi
+fi
 
 if [ "$PASSWORD" != "" ]; then
   if [ ! -f $PASSWD_PATH ]; then
@@ -204,6 +212,17 @@ if [ -f "$DHPARAM_PATH" ]; then
     # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
     ssl_dhparam ${DHPARAM_PATH};
 EOF
+fi
+if [ "$SSL_VERIFY_CLIENT" != "" ]; then
+  cat << EOF >> /tmp/nginx.conf
+    ssl_verify_client $SSL_VERIFY_CLIENT;
+    ssl_verify_depth 2; # support root and intermediate CAs
+EOF
+  if [ "$CERT_CLIENT_PATH" != "" ]; then
+    cat << EOF >> /tmp/nginx.conf
+    ssl_client_certificate $CERT_CLIENT_PATH;
+EOF
+  fi
 fi
 cat << EOF >> /tmp/nginx.conf
 

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -277,9 +277,12 @@ cat << EOF >> /tmp/nginx.conf
       proxy_set_header Sec-Websocket-Version    \$http_sec_websocket_version;
       proxy_set_header Sec-WebSocket-Protocol   \$http_sec_websocket_protocol;
       proxy_set_header Sec-WebSocket-Extensions \$http_sec_websocket_extensions;
-
-
 EOF
+if [ "$ADD_PROXY_HEADER" != "" ]; then
+  cat << EOF >> /tmp/nginx.conf
+      proxy_set_header $ADD_PROXY_HEADER;
+EOF
+fi
 # Check if we need to be low latency
 if [ "$LOW_LATENCY" != "" -o "$LATENCY" == "low"  ]; then
   cat << EOF >> /tmp/nginx.conf


### PR DESCRIPTION
Technically, this pull request:
- Allows addition of a proxy request header via nginx's [proxy_set_header](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header) command using the `ADD_PROXY_HEADER` environment variable
- Adds support for configuring Client Certificate Verification (clients making requests to the proxy must present a trusted certificate before the request will be proxied) - see the [nginx ssl module docs](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_verify_client) using the `SSL_VERIFY_CLIENT` environment variable
  - Can be configured as `on`, `off`, `optional`, `optional_no_ca`
    - All options other than `optional_no_ca` require a certificate of the trusted CA/intermediate CAs, as would be expected, which can be provided using the `CERT_CLIENT_PATH` environment variable

I've added the new arguments and an example of the expected use case to the README.

The simplest way to see this in action is to run the new README example using `SSL_VERIFY_CLIENT=optional_no_ca` to request client certificates but trust them all, bypassing the need for acquiring/generating a CA certificate chain. Here's that case:
```sh
docker run -d \
  --name http-server \
  brndnmtthws/nginx-echo-headers

docker run -d \
  --name verification-proxy \
  -p 443:443 \
  -e 'SERVER_NAME=verification.example.com' \
  -e 'UPSTREAM_TARGET=http-server:8080' \
  -e 'CERT_PUBLIC_PATH=/certs/fullchain.pem' \
  -e 'CERT_PRIVATE_PATH=/certs/privkey.pem' \
  -e 'SSL_VERIFY_CLIENT=optional_no_ca' \
  -e 'ADD_PROXY_HEADER=X-Ssl-Client-Subject $ssl_client_s_dn' \
  -v '/certs:/certs:ro' \
  --link 'http-server:http-server' \
  justsml/ssl-proxy:latest
```

Some design notes and caveats:
- I've hard-coded a client certificate verification depth of 2. This will verify certificates trusted by a root CA and certificates trusted by an intermediate CA, but not certificates trusted by an intermediate CA trusted by an intermediate CA trusted by a root CA (and so on).
- I didn't update the haproxy implementation with these features. I'm not familiar with haproxy, nor does it seem that the haproxy version supports all the features supported by the nginx implementation
- I added a .gitattributes file to force git clients on Windows to check out the .sh files using the correct line endings so that Windows users can build the images. This is outside the scope of the pull request, but was necessary for me to contribute.
