### PR TITLE
Add CORS_ORIGIN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ services:
 |CERT_PUBLIC_PATH   | Reqd. PEM file| Bind-mount certificate files to container path `/certs` - Or override path w/ this var.
 |CERT_PRIVATE_PATH  | Reqd. PEM file| Bind-mount certificate files to container path `/certs` - Or override path w/ this var.
 |SERVER_NAME        | Required      | Primary domain name. Not restricting.
+|CORS_ORIGIN        | Optional      | CORS origin to use for `Access-Control-Allow-Origin` header. Defaults to `SERVER_NAME`.
 |UPSTREAM_TARGET    | Required      | HTTP target host:port. Typically an internally routable address. e.g. `localhost:9090` or `rancher-server:8080`
 |HTTPS_PORT         | 443/Required  | Needed for URL rewriting.
 |ALLOW_RC4          | Not set       | Backwards Compatible Option Required for Java 6 or WinXP/IE8

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -227,6 +227,7 @@ cat << EOF >> /tmp/nginx.conf
         return 204;
       }
 
+      proxy_hide_header 'Access-Control-Allow-Origin';
       add_header 'Access-Control-Allow-Origin' ${CORS_ORIGIN} always;
       add_header 'Access-Control-Allow-Credentials' \$acac always;
       add_header 'Access-Control-Allow-Methods' ${CORS_METHODS-'GET, POST, PUT, DELETE, HEAD, OPTIONS'} always;

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -15,6 +15,7 @@ CERT_PUBLIC_PATH=${CERT_PUBLIC_PATH-"/certs/fullchain.pem"}
 CERT_PRIVATE_PATH=${CERT_PRIVATE_PATH-"/certs/privkey.pem"}
 HTTPS_PORT=${HTTPS_PORT-"443"}
 TLS_PROTOCOLS=${TLS_PROTOCOLS-"TLSv1 TLSv1.1 TLSv1.2"}
+CORS_ORIGIN=${CORS_ORIGIN-"$SERVER_NAME"}
 
 function setupCertbot() {
   if [ "$(which certbot)" == "" ]; then
@@ -216,7 +217,7 @@ cat << EOF >> /tmp/nginx.conf
       }
 
       if (\$request_method = 'OPTIONS') {
-        add_header 'Access-Control-Allow-Origin' $SERVER_NAME always;
+        add_header 'Access-Control-Allow-Origin' ${CORS_ORIGIN} always;
         add_header 'Access-Control-Allow-Credentials' \$acac always;
         add_header 'Access-Control-Allow-Methods' ${CORS_METHODS-'GET, POST, PUT, DELETE, HEAD, OPTIONS'} always;
         add_header 'Access-Control-Allow-Headers' ${CORS_HEADERS-'Sec-WebSocket-Extensions,Sec-WebSocket-Key,Sec-WebSocket-Protocol,Sec-WebSocket-Version,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,x-api-action-links,x-api-csrf,x-api-no-challenge,X-Forwarded-For,X-Real-IP'} always;
@@ -226,7 +227,7 @@ cat << EOF >> /tmp/nginx.conf
         return 204;
       }
 
-      add_header 'Access-Control-Allow-Origin' $SERVER_NAME always;
+      add_header 'Access-Control-Allow-Origin' ${CORS_ORIGIN} always;
       add_header 'Access-Control-Allow-Credentials' \$acac always;
       add_header 'Access-Control-Allow-Methods' ${CORS_METHODS-'GET, POST, PUT, DELETE, HEAD, OPTIONS'} always;
       add_header 'Access-Control-Allow-Headers' ${CORS_HEADERS-'Sec-WebSocket-Extensions,Sec-WebSocket-Key,Sec-WebSocket-Protocol,Sec-WebSocket-Version,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,x-api-action-links,x-api-csrf,x-api-no-challenge,X-Forwarded-For,X-Real-IP'} always;


### PR DESCRIPTION
Fixes #18 

Previously, ssl-proxy assigned the `SERVER_NAME` value to the `Access-Control-Allow-Origin` header (which was not documented).

One issue is that any CORS headers set by the proxied server are overridden here. Another issue is that there is no way to customize the CORS headers, which is important for any API.

In my case, I would have preferred `ssl-proxy` not override the server's headers, but at the very least I needed to be able to set the `Access-Control-Allow-Origin` header myself to a value other than the server name.

This pull request adds an environment variable, `CORS_ORIGIN`, and documents it in the README. If unset, this value will default to that of `SERVER_NAME` to maintain backward compatibility. Otherwise, it allows overriding just the origin header.

I hope this change helps other people in my situation!