### PR TITLE
Allow for customizing the Host request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ services:
 |PASSWORD           |               | Both PASSWORD and USERNAME must be set in order to use Basic authorization
 |PASSWD_PATH        | /etc/nginx/.htpasswd | Alternate auth support (don't combine with USERNAME/PASSWORD) Bind-mount a custom path to `/etc/nginx/.htpasswd`
 |ADD_HEADER         | Not set       | Useful for tagging routes in your infrastructure.
+|PROXY_HEADER_HOST  | Optional       | The host value that will be set in the request header. Defaults to the nginx variable, `'$host'`. Set this value (e.g., to the nginx variable, `'$http_host'`) if including the port number in the `Host` header is important.
 
 
 ===================

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -15,6 +15,7 @@ CERT_PUBLIC_PATH=${CERT_PUBLIC_PATH-"/certs/fullchain.pem"}
 CERT_PRIVATE_PATH=${CERT_PRIVATE_PATH-"/certs/privkey.pem"}
 HTTPS_PORT=${HTTPS_PORT-"443"}
 TLS_PROTOCOLS=${TLS_PROTOCOLS-"TLSv1 TLSv1.1 TLSv1.2"}
+PROXY_HEADER_HOST=${PROXY_HEADER_HOST-'$host'}  # E.g., $host, $http_host, example.com:4443, etc.
 
 function setupCertbot() {
   if [ "$(which certbot)" == "" ]; then
@@ -265,7 +266,7 @@ cat << EOF >> /tmp/nginx.conf
       # add_header Strict-Transport-Security max-age=17968000 always;
       proxy_pass http://upstream;
       proxy_http_version 1.1;
-      proxy_set_header Host \$host;
+      proxy_set_header Host ${PROXY_HEADER_HOST};
       proxy_set_header X-Forwarded-Proto \$scheme;
       proxy_set_header X-Real-IP  \$remote_addr;
       proxy_set_header X-Forwarded-Port \$server_port;


### PR DESCRIPTION
Fixes #19 

This PR adds a variable, `PROXY_HEADER_HOST` to override the behavior, and defaults to the existing value for backward compatibility.

